### PR TITLE
merge idle with more cpu/mem cut and isSNO flag  into IBM release 3.4…

### DIFF
--- a/config/all-in-one/templates/aimanager.yaml
+++ b/config/all-in-one/templates/aimanager.yaml
@@ -48,6 +48,10 @@ spec:
             - name: spec.aiManager.channel
               value: '{{ .Values.cp4waiops.aiManager.channel }}'
             {{- end }}
+            {{- if .Values.cp4waiops.isSNO}}
+            - name: spec.isSNO
+              value: '{{ .Values.cp4waiops.isSNO }}'
+            {{- end }}
             {{- if .Values.cp4waiops.storageClass }}
             - name: spec.storageClass
               value: '{{ .Values.cp4waiops.storageClass }}'

--- a/config/all-in-one/values.yaml
+++ b/config/all-in-one/values.yaml
@@ -1,3 +1,4 @@
+
 # -----------------------------------------------------------------------------
 # Argo CD parameters
 # -----------------------------------------------------------------------------
@@ -72,6 +73,8 @@ cp4waiops:
   # for official installation, use profile such as small or large instead.
   profile: small
 
+  # isSNO: false
+  
   # The storage class for CP4WAIOps to use.
   # storageClass: rook-cephfs
 

--- a/config/cp4waiops-custom/templates/x-small-idle.yaml
+++ b/config/cp4waiops-custom/templates/x-small-idle.yaml
@@ -16,40 +16,40 @@ data:
           min.insync.replicas: 1
         resources:
           limits:
-            cpu: "500m"
-            memory: "1280Mi"
+            cpu: 500m
+            memory: 1280Mi
           requests:
-            cpu: "150m"
-            memory: "500Mi"
+            cpu: 150m
+            memory: 500Mi
       zookeeper:
         replicas: 1
         resources:
           limits:
-            cpu: "200m"
-            memory: "256Mi"
+            cpu: 1000m
+            memory: 256Mi
           requests:
-            cpu: "10m"
-            memory: "128Mi"
+            cpu: 10m
+            memory: 128Mi
       elasticsearch:
         env:
           - name: ES_JAVA_OPTS
-            value: "-Xms512M -Xmx512M"
+            value: -Xms512M -Xmx512M
         replicas: 1
         resources:
           limits:
-            cpu: "150m"
-            memory: "1536Mi"
+            cpu: 500m
+            memory: 1536Mi
           requests:
-            cpu: "10m"
-            memory: "768Mi"
+            cpu: 100m
+            memory: 768Mi
         tls-proxy:
           resources:
             limits:
-              cpu: "100m"
-              memory: "200Mi"
+              cpu: 500m
+              memory: 200Mi
             requests:
-              cpu: "10m"
-              memory: "100Mi"
+              cpu: 10m
+              memory: 100Mi
     cp4waiops-eventprocessor:
       flink:
         # Settings for the jobmanager statefulSet
@@ -57,26 +57,26 @@ data:
           replicas: 1
           resources:
             limits:
-              cpu: "150m"
-              memory: "2560Mi"
+              cpu: 1000m
+              memory: 1Gi
             requests:
-              cpu: "10m"
-              memory: "256Mi"
+              cpu: 100m
+              memory: 1Gi
         # Settings for the taskmanager statefulSet
         taskmanager:
           replicas: 1
           resources:
             limits:
-              cpu: 150m
-              memory: 1888Mi
+              cpu: 1600m
+              memory: 5888Mi
             requests:
-              cpu: 20m
-              memory: 512Mi
+              cpu: 500m
+              memory: 2048Mi
         properties:
-          jobmanager.memory.heap.size: "512mb"
-          jobmanager.memory.jvm-metaspace.size: "128mb"
-          taskmanager.memory.heap.size: "4096mb"
-          taskmanager.memory.managed.size: "512mb"
+          jobmanager.memory.heap.size: 512mb
+          jobmanager.memory.jvm-metaspace.size: 128mb
+          taskmanager.memory.heap.size: 4096mb
+          taskmanager.memory.managed.size: 512mb
           taskmanager.numberOfTaskSlots: 8
     configmaps:
     - name: aiops-topology-sizing
@@ -89,11 +89,11 @@ data:
               cassandra:
                 resources:
                   limits:
-                    cpu: 100m
+                    cpu: 600m
                     memory: 1500Mi
                   requests:
                     cpu: 20m
-                    memory: 768Mi
+                    memory: 512Mi
                 env:
                   - name: CASSANDRA_HEAP_SIZE
                     value: 600M
@@ -116,25 +116,25 @@ data:
           resources:
             db:
               limits:
-                cpu: "200m"
-                memory: "768Mi"
+                cpu: 700m
+                memory: 768Mi
               requests:
-                cpu: "20m"
-                memory: "128Mi"
+                cpu: 20m
+                memory: 64Mi
             search:
               limits:
-                cpu: "100m"
-                memory: "250Mi"
+                cpu: 500m
+                memory: 250Mi
               requests:
-                cpu: "10m"
-                memory: "128Mi"
+                cpu: 10m
+                memory: 64Mi
             mgmt:
               limits:
-                cpu: "100m"
-                memory: "128Mi"
+                cpu: 500m
+                memory: 128Mi
               requests:
-                cpu: "10m"
-                memory: "64Mi"
+                cpu: 10m
+                memory: 64Mi
     - name: redis
       spec:
         redissentinel:
@@ -142,80 +142,80 @@ data:
             member:
               db:
                 limits:
-                  cpu: "100m"
-                  memory: "512Mi"
+                  cpu: 500m
+                  memory: 512Mi
                 requests:
-                  cpu: "20m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 32Mi
               mgmt:
                 limits:
-                  cpu: "200m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "60m"
-                  memory: "64Mi"
+                  cpu: 30m
+                  memory: 64Mi
               proxy:
                 limits:
-                  cpu: "200m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "40m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 32Mi
               proxylog:
                 limits:
-                  cpu: "100m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "10m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 32Mi
             sentinel:
               db:
                 limits:
-                  cpu: "100m"
-                  memory: "512Mi"
+                  cpu: 500m
+                  memory: 512Mi
                 requests:
-                  cpu: "10m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 32Mi
               mgmt:
                 limits:
-                  cpu: "200m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "60m"
-                  memory: "64Mi"
+                  cpu: 30m
+                  memory: 64Mi
               proxy:
                 limits:
-                  cpu: "200m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "50m"
-                  memory: "64Mi"
+                  cpu: 20m
+                  memory: 64Mi
               proxylog:
                 limits:
-                  cpu: "100m"
-                  memory: "150Mi"
+                  cpu: 500m
+                  memory: 150Mi
                 requests:
-                  cpu: "10m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 32Mi
     - name: ir-lifecycle-operator
       spec:
         lifecycleservice:
           customSizing:
             logstash:
-              resourceLimitsCPU: "150m"
-              resourceLimitsMemory: "1536Mi"
-              resourceRequestsCPU: "50m"
-              resourceRequestsMemory: "600Mi"
+              resourceLimitsCPU: 625m
+              resourceLimitsMemory: 1536Mi
+              resourceRequestsCPU: 20m
+              resourceRequestsMemory: 600Mi
             taskManager:
-              resourceLimitsCPU: "200m"
-              resourceLimitsMemory: "1280Mi"
-              resourceRequestsCPU: "50m"
-              resourceRequestsMemory: "256Mi"
+              resourceLimitsCPU: 500m
+              resourceLimitsMemory: 1280Mi
+              resourceRequestsCPU: 250m
+              resourceRequestsMemory: 1280Mi
             jobManager:
-              resourceLimitsCPU: "100m"
-              resourceLimitsMemory: "768Mi"
-              resourceRequestsCPU: "20m"
-              resourceRequestsMemory: "256Mi"
+              resourceLimitsCPU: 600m
+              resourceLimitsMemory: 768Mi
+              resourceRequestsCPU: 100m
+              resourceRequestsMemory: 512Mi
     - name: ir-ai-operator
       spec:
         aiopsanalyticsorchestrator:
@@ -226,41 +226,84 @@ data:
                 containers:
                 - name: probablecause
                   limits:
-                    cpu: "100m"
-                    memory: "1Gi"
+                    cpu: 1000m
+                    memory: 1Gi
                   requests:
-                    cpu: "10m"
-                    memory: "256Mi"
+                    cpu: 20m
+                    memory: 300Mi
               - name: classifier
                 replicas: 1
                 containers:
                 - name: classifier
                   limits:
-                    cpu: "100m"
-                    memory: "2048Mi"
+                    cpu: 1
+                    memory: 2048Mi
                   requests:
-                    cpu: "20m"
-                    memory: "128Mi"
+                    cpu: 10m
+                    memory: 64Mi
+
+              - name: metric-action
+                replicas: 1
+                containers:
+                - name: metric-action
+                  limits:
+                    cpu: 1000m
+                    memory: 1500Mi
+                  requests:
+                    cpu: 50m
+                    memory: 100Mi
+              - name: metric-api
+                replicas: 1
+                containers:
+                - name: metric-api
+                  limits:
+                    cpu: 1000m
+                    memory: 1500Mi
+                  requests:
+                    cpu: 50m
+                    memory: 100Mi
+              - name: metric-spark
+                replicas: 1
+                containers:
+                - name: metric-spark
+                  limits:
+                    cpu: 1000m
+                    memory: 1500Mi
+                  requests:
+                    cpu: 50m
+                    memory: 100Mi
+
+              - name: spark-master
+                replicas: 1
+                containers:
+                - name: spark-master
+                  limits:
+                    cpu: 600m
+                    memory: 488Mi
+                  requests:
+                    cpu: 50m
+                    memory: 128Mi
+
               - name: spark-worker
                 replicas: 1
                 containers:
                 - name: spark-worker
                   limits:
-                    cpu: "100m"
-                    memory: "1000Mi"
+                    cpu: 1
+                    memory: 1000Mi
                   requests:
-                    cpu: "10m"
-                    memory: "512Mi"
+                    cpu: 10m
+                    memory: 256Mi
               - name: spark-pipeline-composer
                 replicas: 1
                 containers:
                 - name: spark-pipeline-composer
                   limits:
-                    cpu: "100m"
-                    memory: "896Mi"
+                    cpu: 250m
+                    memory: 896Mi
                   requests:
-                    cpu: "10m"
-                    memory: "256Mi"
+                    cpu: 20m
+                    memory: 128Mi
     - name: ir-core-operator
       spec:
         issueresolutioncore:
@@ -271,89 +314,89 @@ data:
                 containers:
                 - name: api
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 60m
+                    memory: 128Mi
               - name: ncodl-if
                 replicas: 1
                 containers:
                 - name: iducforward
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 10m
+                    memory: 128Mi
               - name: ncodl-ir
                 replicas: 1
                 containers:
                 - name: iducrelay
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 10m
+                    memory: 128Mi
               - name: ncodl-jobmgr
                 replicas: 1
                 containers:
                 - name: jobmgr
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 10m
+                    memory: 128Mi
               - name: ncodl-std
                 replicas: 1
                 containers:
                 - name: standard
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 20m
+                    memory: 128Mi
               - name: logstash
                 replicas: 1
                 containers:
                 - name: logstash
                   limits:
-                    cpu: "150m"
-                    memory: "1792Mi"
+                    cpu: 1000m
+                    memory: 1792Mi
                   requests:
-                    cpu: "30m"
-                    memory: "512Mi"
+                    cpu: 20m
+                    memory: 512Mi
             statefulSets:
               - name: ncobackup
                 replicas: 1
                 containers:
                 - name: agg-gate
                   limits:
-                    cpu: "100m"
-                    memory: "512Mi"
+                    cpu: 500m
+                    memory: 512Mi
                   requests:
-                    cpu: "10m"
-                    memory: "64Mi"
+                    cpu: 10m
+                    memory: 64Mi
                 - name: objserv
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "10m"
-                    memory: "64Mi"
+                    cpu: 10m
+                    memory: 64Mi
               - name: ncoprimary
                 replicas: 1
                 containers:
                 - name: objserv
                   limits:
-                    cpu: "100m"
-                    memory: "1024Mi"  
+                    cpu: 500m
+                    memory: 1024Mi  
                   requests:
-                    cpu: "10m"
-                    memory: "128Mi"
+                    cpu: 10m
+                    memory: 50Mi
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: ResourceLocker
@@ -369,27 +412,69 @@ spec:
           changeRisk:
             resources:
               limits:
-                cpu: "750m"
-                memory: "1400Mi"
+                cpu: 750m
+                memory: 1400Mi
               requests:
-                cpu: "500m"
-                memory: "1000Mi"
+                cpu: 50m
+                memory: 500Mi
           logAnomaly:
             resources:
               limits:
-                cpu: "500m"
-                memory: "2048Mi"
+                cpu: 500m
+                memory: 2048Mi
               requests:
-                cpu: "250m"
-                memory: "128Mi"
+                cpu: 250m
+                memory: 128Mi
           aiPlatformApiServer:
             resources:
               limits:
-                cpu: "200m"
-                memory: "2Gi"
+                cpu: 200m
+                memory: 2Gi
               requests:
-                cpu: "100m"
-                memory: "128Mi"
+                cpu: 10m
+                memory: 50Mi
+          controller:
+            resources:
+              limits:
+                cpu: 1000m               
+                memory: 1Gi
+              requests:
+                cpu: 50m
+                memory: 100Mi
+
+          similarIncidents:
+            resources:
+              limits:
+                memory: 2Gi
+                cpu: 800m                  
+              requests:
+                cpu: 40m
+                memory: 256Mi
+          chatopsSlackIntegrator:
+            resources:
+              limits:
+                cpu: 300m
+                memory: 512Mi
+              requests:
+                cpu: 20m
+                memory: 128Mi        
+          chatopsTeamsIntegrator:
+            resources:
+              limits:
+                cpu: 300m
+                memory: 512Mi                  
+              requests:
+                cpu: 20m
+                memory: 128Mi        
+          chatopsOrchestrator:
+            resources:
+              limits:
+                cpu: 200m
+                memory: 1Gi
+              requests:
+                cpu: 20m
+                memory: 88Mi        
+
           global:
             logAnomaly:
               replicas: 1
@@ -457,27 +542,27 @@ spec:
             tlsSidecar:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "128Mi"
+                  cpu: 500m
+                  memory: 128Mi
                 requests:
-                  cpu: "100m"
-                  memory: "64Mi"
+                  cpu: 10m
+                  memory: 16Mi
             topicOperator:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "256Mi"
+                  cpu: 500m
+                  memory: 256Mi
                 requests:
-                  cpu: "100m"
-                  memory: "256Mi"
+                  cpu: 10m
+                  memory: 100Mi
             userOperator:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "256Mi"
+                  cpu: 500m
+                  memory: 256Mi
                 requests:
-                  cpu: "100m"
-                  memory: "256Mi"
+                  cpu: 10m
+                  memory: 100Mi
     patchType: application/merge-patch+json
     targetObjectRef:
       apiVersion: base.automation.ibm.com/v1beta1
@@ -506,4 +591,5 @@ spec:
       namespace: {{.Values.aiManager.namespace}}
   serviceAccountRef:
     name: resource-locker-operator-controller-manager
+
 {{- end }}

--- a/config/cp4waiops-custom/templates/x-small.yaml
+++ b/config/cp4waiops-custom/templates/x-small.yaml
@@ -16,8 +16,8 @@ data:
           min.insync.replicas: 1
         resources:
           limits:
-            cpu: "500m"
-            memory: "1280Mi"
+            cpu: 500m
+            memory: 1280Mi
           requests:
             cpu: 250m
             memory: 500Mi
@@ -116,25 +116,25 @@ data:
           resources:
             db:
               limits:
-                cpu: "700m"
-                memory: "768Mi"
+                cpu: 700m
+                memory: 768Mi
               requests:
-                cpu: "250m"
-                memory: "768Mi"
+                cpu: 250m
+                memory: 768Mi
             search:
               limits:
-                cpu: "500m"
-                memory: "250Mi"
+                cpu: 500m
+                memory: 250Mi
               requests:
-                cpu: "250m"
-                memory: "250Mi"
+                cpu: 250m
+                memory: 250Mi
             mgmt:
               limits:
-                cpu: "500m"
-                memory: "128Mi"
+                cpu: 500m
+                memory: 128Mi
               requests:
-                cpu: "250m"
-                memory: "64Mi"
+                cpu: 250m
+                memory: 64Mi
     - name: redis
       spec:
         redissentinel:
@@ -142,80 +142,80 @@ data:
             member:
               db:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 512Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 256Mi
               mgmt:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
               proxy:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
               proxylog:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
             sentinel:
               db:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 512Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 256Mi
               mgmt:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
               proxy:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
               proxylog:
                 limits:
-                  cpu: "500m"
+                  cpu: 500m
                   memory: 150Mi
                 requests:
-                  cpu: "60m"
+                  cpu: 60m
                   memory: 100Mi
     - name: ir-lifecycle-operator
       spec:
         lifecycleservice:
           customSizing:
             logstash:
-              resourceLimitsCPU: "625m"
-              resourceLimitsMemory: "1536Mi"
-              resourceRequestsCPU: "250m"
-              resourceRequestsMemory: "600Mi"
+              resourceLimitsCPU: 625m
+              resourceLimitsMemory: 1536Mi
+              resourceRequestsCPU: 250m
+              resourceRequestsMemory: 600Mi
             taskManager:
-              resourceLimitsCPU: "500m"
-              resourceLimitsMemory: "1280Mi"
-              resourceRequestsCPU: "250m"
-              resourceRequestsMemory: "1280Mi"
+              resourceLimitsCPU: 500m
+              resourceLimitsMemory: 1280Mi
+              resourceRequestsCPU: 250m
+              resourceRequestsMemory: 1280Mi
             jobManager:
-              resourceLimitsCPU: "600m"
-              resourceLimitsMemory: "768Mi"
-              resourceRequestsCPU: "100m"
-              resourceRequestsMemory: "512Mi"
+              resourceLimitsCPU: 600m
+              resourceLimitsMemory: 768Mi
+              resourceRequestsCPU: 100m
+              resourceRequestsMemory: 512Mi
     - name: ir-ai-operator
       spec:
         aiopsanalyticsorchestrator:
@@ -226,41 +226,41 @@ data:
                 containers:
                 - name: probablecause
                   limits:
-                    cpu: "1000m"
-                    memory: "1Gi"
+                    cpu: 1000m
+                    memory: 1Gi
                   requests:
-                    cpu: "400m"
-                    memory: "750Mi"
+                    cpu: 400m
+                    memory: 750Mi
               - name: classifier
                 replicas: 1
                 containers:
                 - name: classifier
                   limits:
-                    cpu: "1"
-                    memory: "2048Mi"
+                    cpu: 1
+                    memory: 2048Mi
                   requests:
-                    cpu: "400m"
-                    memory: "750Mi"
+                    cpu: 400m
+                    memory: 750Mi
               - name: spark-worker
                 replicas: 1
                 containers:
                 - name: spark-worker
                   limits:
-                    cpu: "1"
-                    memory: "1000Mi"
+                    cpu: 1
+                    memory: 1000Mi
                   requests:
-                    cpu: "350m"
-                    memory: "1000Mi"
+                    cpu: 350m
+                    memory: 1000Mi
               - name: spark-pipeline-composer
                 replicas: 1
                 containers:
                 - name: spark-pipeline-composer
                   limits:
-                    cpu: "250m"
-                    memory: "896Mi"
+                    cpu: 250m
+                    memory: 896Mi
                   requests:
-                    cpu: "250m"
-                    memory: "600Mi"
+                    cpu: 250m
+                    memory: 600Mi
     - name: ir-core-operator
       spec:
         issueresolutioncore:
@@ -271,89 +271,89 @@ data:
                 containers:
                 - name: api
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "100m"
-                    memory: "512Mi"
+                    cpu: 100m
+                    memory: 512Mi
               - name: ncodl-if
                 replicas: 1
                 containers:
                 - name: iducforward
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "100m"
-                    memory: "512Mi"
+                    cpu: 100m
+                    memory: 512Mi
               - name: ncodl-ir
                 replicas: 1
                 containers:
                 - name: iducrelay
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "50m"
-                    memory: "512Mi"
+                    cpu: 50m
+                    memory: 512Mi
               - name: ncodl-jobmgr
                 replicas: 1
                 containers:
                 - name: jobmgr
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "50m"
-                    memory: "512Mi"
+                    cpu: 50m
+                    memory: 512Mi
               - name: ncodl-std
                 replicas: 1
                 containers:
                 - name: standard
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "50m"
-                    memory: "512Mi"
+                    cpu: 50m
+                    memory: 512Mi
               - name: logstash
                 replicas: 1
                 containers:
                 - name: logstash
                   limits:
-                    cpu: "500m"
-                    memory: "1792Mi"
+                    cpu: 1000m
+                    memory: 1792Mi
                   requests:
-                    cpu: "100m"
-                    memory: "700Mi"
+                    cpu: 100m
+                    memory: 700Mi
             statefulsets:
               - name: ncobackup
                 replicas: 1
                 containers:
                 - name: agg-gate
                   limits:
-                    cpu: "500m"
-                    memory: "512Mi"
+                    cpu: 500m
+                    memory: 512Mi
                   requests:
-                    cpu: "50m"
-                    memory: "256Mi"
+                    cpu: 50m
+                    memory: 256Mi
                 - name: objserv
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"
+                    cpu: 500m
+                    memory: 1024Mi
                   requests:
-                    cpu: "100m"
-                    memory: "512Mi"
+                    cpu: 100m
+                    memory: 512Mi
               - name: ncoprimary
                 replicas: 1
                 containers:
                 - name: objserv
                   limits:
-                    cpu: "500m"
-                    memory: "1024Mi"  
+                    cpu: 500m
+                    memory: 1024Mi  
                   requests:
-                    cpu: "125m"
-                    memory: "512Mi"
+                    cpu: 125m
+                    memory: 512Mi
 ---
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: ResourceLocker
@@ -369,27 +369,27 @@ spec:
           changeRisk:
             resources:
               limits:
-                cpu: "750m"
-                memory: "1400Mi"
+                cpu: 750m
+                memory: 1400Mi
               requests:
-                cpu: "500m"
-                memory: "1000Mi"
+                cpu: 500m
+                memory: 1000Mi
           logAnomaly:
             resources:
               limits:
-                cpu: "500m"
-                memory: "2048Mi"
+                cpu: 500m
+                memory: 2048Mi
               requests:
-                cpu: "250m"
-                memory: "256Mi"
+                cpu: 250m
+                memory: 256Mi
           aiPlatformApiServer:
             resources:
               limits:
-                cpu: "200m"
-                memory: "2Gi"
+                cpu: 200m
+                memory: 2Gi
               requests:
-                cpu: "100m"
-                memory: "512Mi"
+                cpu: 100m
+                memory: 512Mi
           global:
             logAnomaly:
               replicas: 1
@@ -457,27 +457,27 @@ spec:
             tlsSidecar:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "128Mi"
+                  cpu: 500m
+                  memory: 128Mi
                 requests:
-                  cpu: "100m"
-                  memory: "64Mi"
+                  cpu: 100m
+                  memory: 64Mi
             topicOperator:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "256Mi"
+                  cpu: 500m
+                  memory: 256Mi
                 requests:
-                  cpu: "100m"
-                  memory: "256Mi"
+                  cpu: 100m
+                  memory: 256Mi
             userOperator:
               resources:
                 limits:
-                  cpu: "500m"
-                  memory: "256Mi"
+                  cpu: 500m
+                  memory: 256Mi
                 requests:
-                  cpu: "100m"
-                  memory: "256Mi"
+                  cpu: 100m
+                  memory: 256Mi
     patchType: application/merge-patch+json
     targetObjectRef:
       apiVersion: base.automation.ibm.com/v1beta1

--- a/config/cp4waiops/install-aimgr/templates/resources/075-redis-locker.yaml
+++ b/config/cp4waiops/install-aimgr/templates/resources/075-redis-locker.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.spec.isSNO  }}
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: ResourceLocker
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "75"
+  name: redis-resource-locker
+  namespace: resource-locker-operator
+spec:
+  patches:
+  - id: redis-sen-locker
+    patchTemplate: |
+      spec:
+        size: 2
+        members:
+          affinity:
+            podAntiAffinity: null
+    patchType: application/merge-patch+json
+    targetObjectRef:
+      apiVersion: redis.databases.cloud.ibm.com/v1
+      kind: RedisSentinel
+      name: example-redis
+      namespace: {{.Values.spec.aiManager.namespace}}
+  serviceAccountRef:
+    name: resource-locker-operator-controller-manager
+{{- end }}

--- a/config/cp4waiops/install-aimgr/values.yaml
+++ b/config/cp4waiops/install-aimgr/values.yaml
@@ -28,6 +28,9 @@ spec:
   ##
   storageClass: rook-cephfs
 
+  ## is ocp SNO? if yes, will adjust redis 
+  # isSNO: false
+
   ## If the storage provider for your deployment is Red Hat OpenShift Data Foundation, 
   ## previously called Red Hat OpenShift Container Storage, then set this to ocs-storagecluster-ceph-rbd
   storageClassLargeBlock: rook-cephfs


### PR DESCRIPTION
… (#171)

* sync targetRevision for cp4waiops-custom in release-3.4

* add xsmall-idle-configmap.yaml

* update all-in-one cp4waiops-custom.yaml for custom sizing idle

* copy from values.x-small.yaml

* update data in values for idle

* update data in values for idle for lad

* remove xsmall-idle-configmap.yaml for generic cm + values.x-small-idle.yaml

* update for x-small-idle

* update for x-small-idle

* update custom repo and branch in allIn1

* same with IBM new layout

* original hardcode configmap

* fix cpu 100 and increase kafka mem limit

* same with IBM

* rename to custom-size-configmap.yaml

* withdraw sync latest

* withdraw sync latest

* sync idle stuff from release-3.4

* fix zen cm name

* sync idle stuff from release-3.4

* fix zen cm name

* merge ai,app,iaf into cm

* remove zen config in cm

* remove seperate ai,app,iaf for merged into cm

* rename configmap

* update all-in-one for custom

* resume nginx,zen-core in iaf for remove zen config

* update value in x-small.yaml

* remove values.x-small-idle.yaml

* magic es in custom

* update per PR comment

* try to fix event crash with xsmall values

* try to fix restart pods

* try to fix restart pods

* same taskmgr, jobmgr, probablecause with xsmall

* half request of taskmgr, jobmgr to xsmall after same good

* try to decrease event flink

* try to same with lifecycle flink

* Revert "try to same with lifecycle flink"

This reverts commit d48af73bb9605ce9a3236f36a4205d0a9585f3c6.

* Revert "try to decrease event flink"

This reverts commit a62b42571962bf1c4e437f06a043a3dbd225f78f.

* Revert "half request of taskmgr, jobmgr to xsmall after same good"

This reverts commit 31441abf3b526e616c0b0d09e2e258064fc7f03f.

* format by removing quote

* try to decrease idle request of mem, cpu

* try to fix restart pods of es, loganomal, api

* same limit with x-small

* increase logstash cpu limit to 1

* add common-services-resource-locker of 3.3

* decrease iaf cpu/mem in common-services-resource-locker

* decrease spark worker, pipeline cpu/mem

* add ir-analytics-metric

* add spark-master

* remove hardcode ceph in common service locker

* add similarIncidents, chatops

* remove commonservice locker

* add switch isSNO for sno

* add switch isSNO for sno: merge

* move isSNO to aimgr

* adjust order of redis lockere

* restart redis in locker

* set replicas in redis locker

* remove sts in redis locker for syncd by cr

* hiden isSNO in all-in-one and aimanager

Co-authored-by: MorningSpace <morningspace@yahoo.com>