### PR TITLE
merge custom build with imagecatalog into release 3.4  (#172)

### DIFF
--- a/config/all-in-one/templates/aimanager.yaml
+++ b/config/all-in-one/templates/aimanager.yaml
@@ -40,9 +40,9 @@ spec:
             - name: spec.aiManager.size
               value: '{{ .Values.cp4waiops.profile }}'
             {{- end }}
-            {{- if .Values.cp4waiops.aiManager.imageCatalog }}
+            {{- if .Values.cp4waiops.imageCatalog }}
             - name: spec.imageCatalog
-              value: '{{ .Values.cp4waiops.aiManager.imageCatalog }}'
+              value: '{{ .Values.cp4waiops.imageCatalog }}'
             {{- end }}
             {{- if .Values.cp4waiops.aiManager.channel }}
             - name: spec.aiManager.channel

--- a/config/all-in-one/templates/cp-shared.yaml
+++ b/config/all-in-one/templates/cp-shared.yaml
@@ -11,8 +11,14 @@ spec:
   project: default
   source:
     path: config/cp-shared/operators
-    repoURL: https://github.com/IBM/cp4waiops-gitops
-    targetRevision: release-3.4
+    repoURL: {{ default "https://github.com/IBM/cp4waiops-gitops" .Values.cp4waiops.repoURL }}
+    targetRevision: {{ default "release-3.4" .Values.cp4waiops.targetRevision }}
+    helm:
+      parameters:
+        {{- if .Values.cp4waiops.imageCatalog }}
+        - name: spec.imageCatalog
+          value: '{{ .Values.cp4waiops.imageCatalog }}'
+        {{- end }}
   syncPolicy:
     automated:
       prune: true

--- a/config/all-in-one/values.yaml
+++ b/config/all-in-one/values.yaml
@@ -81,6 +81,9 @@ cp4waiops:
   # The storage class for large block for CP4WAIOps to use.
   # storageClassLargeBlock: rook-cephfs
 
+  # imageCatalog for cp-shared, ai-manager and event-manager, override if custom build is used
+  # imageCatalog: icr.io/cpopen/ibm-operator-catalog:latest
+
   # AIManager specific configuration
   aiManager:
     # Specify whether or not to install AI Manager.
@@ -89,6 +92,8 @@ cp4waiops:
     instanceName: aiops-installation
     # The namespace where AI Manager is installed.
     namespace: cp4waiops
+    # The channel used to subscribe AI Manager
+    # channel: v3.4
 
   eventManager:
     # Specify whether or not to install Event Manager.

--- a/config/cp4waiops/install-aimgr/values.yaml
+++ b/config/cp4waiops/install-aimgr/values.yaml
@@ -43,7 +43,7 @@ spec:
     ## A channel defines a stream of updates for an Operator and is used to roll out updates for subscribers.
     ## For example, if you want to install AI Manager 3.2, the channel should be v3.2
     ##
-    channel: v3.3
+    channel: v3.4
 
     ## size is the size that you require for your AI Manager installation. It can be small or large.
     ## More information: https://www.ibm.com/docs/en/cloud-paks/cloud-pak-watson-aiops/3.2.0?topic=requirements-ai-manager


### PR DESCRIPTION
* sync targetRevision for cp4waiops-custom in release-3.4

* add xsmall-idle-configmap.yaml

* update all-in-one cp4waiops-custom.yaml for custom sizing idle

* copy from values.x-small.yaml

* update data in values for idle

* update data in values for idle for lad

* remove xsmall-idle-configmap.yaml for generic cm + values.x-small-idle.yaml

* update for x-small-idle

* update for x-small-idle

* update custom repo and branch in allIn1

* same with IBM new layout

* original hardcode configmap

* fix cpu 100 and increase kafka mem limit

* same with IBM

* rename to custom-size-configmap.yaml

* withdraw sync latest

* withdraw sync latest

* sync idle stuff from release-3.4

* fix zen cm name

* sync idle stuff from release-3.4

* fix zen cm name

* merge ai,app,iaf into cm

* remove zen config in cm

* remove seperate ai,app,iaf for merged into cm

* rename configmap

* update all-in-one for custom

* resume nginx,zen-core in iaf for remove zen config

* update value in x-small.yaml

* remove values.x-small-idle.yaml

* magic es in custom

* update per PR comment

* try to fix event crash with xsmall values

* try to fix restart pods

* try to fix restart pods

* same taskmgr, jobmgr, probablecause with xsmall

* half request of taskmgr, jobmgr to xsmall after same good

* try to decrease event flink

* try to same with lifecycle flink

* Revert "try to same with lifecycle flink"

This reverts commit d48af73bb9605ce9a3236f36a4205d0a9585f3c6.

* Revert "try to decrease event flink"

This reverts commit a62b42571962bf1c4e437f06a043a3dbd225f78f.

* Revert "half request of taskmgr, jobmgr to xsmall after same good"

This reverts commit 31441abf3b526e616c0b0d09e2e258064fc7f03f.

* format by removing quote

* try to decrease idle request of mem, cpu

* try to fix restart pods of es, loganomal, api

* same limit with x-small

* increase logstash cpu limit to 1

* add common-services-resource-locker of 3.3

* decrease iaf cpu/mem in common-services-resource-locker

* decrease spark worker, pipeline cpu/mem

* add ir-analytics-metric

* add spark-master

* remove hardcode ceph in common service locker

* add similarIncidents, chatops

* remove commonservice locker

* add switch isSNO for sno

* add switch isSNO for sno: merge

* move isSNO to aimgr

* adjust order of redis lockere

* restart redis in locker

* set replicas in redis locker

* remove sts in redis locker for syncd by cr

* add custom imageCatalog in all-in-one

* hiden isSNO in all-in-one and aimanager

* hiden isSNO in all-in-one and aimanager

* add aiManager.channel for custom build

* add custom repoURL and targetVersion

* move imageCatalog into aiManager

* remove imageCatalog from values for moved into cp-shared

* tidy empty line

* revert move imageCatalog into aiManager

* update per PR review

* Update config/all-in-one/values.yaml

* Update config/all-in-one/values.yaml

Co-authored-by: MorningSpace <morningspace@yahoo.com>